### PR TITLE
[Bug/COC-39] 개념글 삭제 시 해당 개념글에 의존하고 있는 모든 리소스가 S3 에서도 모두 삭제될 수 있도록 수정

### DIFF
--- a/app/models/storage_board.rb
+++ b/app/models/storage_board.rb
@@ -4,7 +4,7 @@ class StorageBoard < ApplicationRecord
 
   has_many :storage_board_comments, dependent: :destroy
   has_many :storage_board_recommend_logs, dependent: :destroy
-  has_many_attached :images, dependent: :destroy
+  has_many_attached :images
 
   validate :nickname_inspection, on: %i[update]
   validate :password_minimum_length, on: %i[update]


### PR DESCRIPTION
## 타입
- [ ] New Feature
- [ ] Improve
- [x] Bug Fix
- [ ] Setup
- [ ] Other

## 내용
- StorageBoard Model 에 잘못된 dependent 지정으로 인, record 삭제 시 관련된 S3 리소스가 삭제되지 않던 부분 수정
## 체크리스트
- [ ] 없음